### PR TITLE
Fix ignoring DATA_PATH env var in titleIdManager

### DIFF
--- a/src/titleIdManager.ts
+++ b/src/titleIdManager.ts
@@ -11,10 +11,11 @@ class TitleIdManager {
   private refreshInterval: NodeJS.Timeout | null = null;
 
   constructor() {
-    this.filePath = "/data/ryuldn/otherTitleIds.txt";
+    const dataDirectory = process.env.DATA_PATH ?? "data";
+    this.filePath = `${dataDirectory}/ryuldn/otherTitleIds.txt`;
     
     if (!existsSync(this.filePath)) {
-      mkdirSync("/data/ryuldn", { recursive: true });
+      mkdirSync(dataDirectory, { recursive: true });
       writeFileSync(this.filePath, "", "utf8");
     }
     


### PR DESCRIPTION
Hello, this should be pretty self-explaining.
The titleIdManager had a hardcoded data dir value and didn't follow the DATA_PATH variable.